### PR TITLE
Use roundHistory data for Blackbox jnlp download

### DIFF
--- a/src/fumbbl/pages/gamefinder/GameFinder.vue
+++ b/src/fumbbl/pages/gamefinder/GameFinder.vue
@@ -256,6 +256,15 @@ import { AxiosError } from "axios";
                 this.refreshBlackboxRoundHistory();
             }
         },
+        'matchesAndTeamsState.blackbox.userActivated'(newVal, oldVal) {
+            // @ts-ignore
+            this.blackboxJoiningDraw = {
+                displaySecondsUntilDraw: 0,
+                previousRoundTimestamp: null,
+                drawnRoundTimestamp: null,
+                downloadJnlpId: null,
+            };
+        },
     }
 })
 export default class GameFinder extends Vue {
@@ -856,21 +865,11 @@ export default class GameFinder extends Vue {
         this.allowRejoinAfterDownload = false;
         this.schedulingErrorMessage = null;
 
-        this.blackboxReset();
+        await this.backendApi.blackboxDeactivate();
 
         await this.activate();
         await this.getState();
         this.stateUpdatesArePaused = false;
-    }
-
-    public blackboxReset() {
-        this.blackboxJoiningDraw = {
-            displaySecondsUntilDraw: 0,
-            previousRoundTimestamp: null,
-            drawnRoundTimestamp: null,
-            downloadJnlpId: null,
-        };
-        this.backendApi.blackboxDeactivate();
     }
 
     public get blackboxTeamCount(): number {
@@ -894,7 +893,7 @@ export default class GameFinder extends Vue {
     }
 
     public handleBlackboxDeactivation(): void {
-        this.blackboxReset();
+        this.backendApi.blackboxDeactivate();
     }
 
     public async refreshBlackboxRoundHistory() {

--- a/src/fumbbl/pages/gamefinder/components/Offers.vue
+++ b/src/fumbbl/pages/gamefinder/components/Offers.vue
@@ -168,7 +168,6 @@ export default class OffersComponent extends Vue {
 
             if (offer.clientId && offer.clientId !== 0) {
                 downloadJnlpOffer = offerCreated;
-                downloadJnlpOffer.isBlackbox = offer.clientId === -1; // Blackbox offers always have a clientId of -1
             }
 
             if (offer.schedulingError) {
@@ -186,10 +185,6 @@ export default class OffersComponent extends Vue {
         this.$emit('launch-game', launchGameOffer);
         this.$emit('download-jnlp', downloadJnlpOffer);
         this.$emit('scheduling-error', schedulingErrorMessage);
-
-        if (downloadJnlpOffer !== null && downloadJnlpOffer.isBlackbox) {
-            this.$emit('blackbox-download-jnlp-id', downloadJnlpOffer.home.id);
-        }
     }
 
     private processOffers() {

--- a/src/fumbbl/pages/gamefinder/include/IBackendApi.ts
+++ b/src/fumbbl/pages/gamefinder/include/IBackendApi.ts
@@ -39,9 +39,9 @@ export default interface IBackendApi {
 
     blackboxConfig(): Promise<BlackboxConfig>;
 
-    blackboxActivate(): void;
+    blackboxActivate(): Promise<void>;
 
-    blackboxDeactivate(): void;
+    blackboxDeactivate(): Promise<void>;
 
     blackboxRoundHistory(): Promise<any[]>;
 }


### PR DESCRIPTION
Main change fixes bugs with intermittent failures to launch downloads. We know the round has been drawn and the 
data is in the roundHistory, so just check if our user has a match there and trigger the download.

Also watch blackbox.userActivated for changes, to know when to reset the blackboxJoiningDraw settings.